### PR TITLE
Update Instagram API scope to 'instagram_business_basic'

### DIFF
--- a/src/Two/InstagramBusinessProvider.php
+++ b/src/Two/InstagramBusinessProvider.php
@@ -30,7 +30,7 @@ class InstagramBusinessProvider extends AbstractProvider
     /**
      * {@inheritdoc}
      */
-    protected $scopes = ['business_basic'];
+    protected $scopes = ['instagram_business_basic'];
 
     /**
      * {@inheritdoc}


### PR DESCRIPTION
To ensure consistency between scope values and permission names, we are introducing new scope values for the Instagram API with Instagram login. The new scope values are:

instagram_business_basic
instagram_business_content_publish
instagram_business_manage_messages
instagram_business_manage_comments

These will replace the existing business_basic, business_content_publish, business_manage_comments and business_manage_messages scope values, respectively.

Please note that the old scope values will be deprecated on ** January 27, 2025 **. It is essential to update your code before this date to avoid any disruption in your app's functionality. Failure to do so will result in your app being unable to call the Instagram endpoints.